### PR TITLE
declare functions static to allow inlining, eliminate IRQ vectors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,13 +11,20 @@ MCU = attiny10
 OBJS = $(PROJ)/main.o
 LIBS = -lm
 
+CFLAGS := -Os -std=gnu99 -mmcu=$(MCU)
+CFLAGS += -Wall
+CFLAGS += -funsigned-char -funsigned-bitfields -ffunction-sections -fdata-sections -fpack-struct -fshort-enums
+CFLAGS += -nostartfiles
+
+LDFLAGS :=
+
 all:		$(PROJ).elf
 
 $(PROJ)/main.o:	$(PROJ)/main.c
-		avr-gcc -Os -x c -funsigned-char -funsigned-bitfields -DNDEBUG -ffunction-sections -fdata-sections -fpack-struct -fshort-enums -Wall -mmcu=$(MCU) -std=gnu99 -c -o $(@) $(<)
+		avr-gcc $(CPPFLAGS) $(CFLAGS) -c -o $(@) $(<)
 
 $(PROJ).elf:	$(OBJS)
-	avr-gcc -o $(@) $(OBJS) $(LIBS) -Wl,-Map=$(PROJ).map -Wl,--start-group -Wl,-lm  -Wl,--end-group -Wl,--gc-sections -mmcu=$(MCU)
+	avr-gcc -o $(@) $(OBJS) $(LIBS) $(CFLAGS) $(LDFLAGS) -Wl,-Map=$(PROJ).map -Wl,--start-group -Wl,-lm  -Wl,--end-group -Wl,--gc-sections
 	avr-objcopy -O ihex -R .eeprom -R .fuse -R .lock -R .signature -R .user_signatures  $(@) $(PROJ).hex
 	avr-objcopy -j .eeprom  --set-section-flags=.eeprom=alloc,load --change-section-lma .eeprom=0  --no-change-warnings -O ihex $(PROJ).elf $(PROJ).eep || exit 0
 	avr-objdump -h -S $(@) > $(PROJ).lss

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+#
+# compilation requires avr-gcc 5.4.0 - later versions generate bloated binaries
+#
+# get the AVR 8-bit Toolchain 3.6.2 from
+# https://www.microchip.com/en-us/development-tools-tools-and-software/gcc-compilers-avr-and-arm
+#
+
+PROJ = VideoGame
+MCU = attiny10
+
+OBJS = $(PROJ)/main.o
+LIBS = -lm
+
+all:		$(PROJ).elf
+
+$(PROJ)/main.o:	$(PROJ)/main.c
+		avr-gcc -Os -x c -funsigned-char -funsigned-bitfields -DNDEBUG -ffunction-sections -fdata-sections -fpack-struct -fshort-enums -Wall -mmcu=$(MCU) -std=gnu99 -c -o $(@) $(<)
+
+$(PROJ).elf:	$(OBJS)
+	avr-gcc -o $(@) $(OBJS) $(LIBS) -Wl,-Map=$(PROJ).map -Wl,--start-group -Wl,-lm  -Wl,--end-group -Wl,--gc-sections -mmcu=$(MCU)
+	avr-objcopy -O ihex -R .eeprom -R .fuse -R .lock -R .signature -R .user_signatures  $(@) $(PROJ).hex
+	avr-objcopy -j .eeprom  --set-section-flags=.eeprom=alloc,load --change-section-lma .eeprom=0  --no-change-warnings -O ihex $(PROJ).elf $(PROJ).eep || exit 0
+	avr-objdump -h -S $(@) > $(PROJ).lss
+	avr-objcopy -O srec -R .eeprom -R .fuse -R .lock -R .signature -R .user_signatures $(@) $(PROJ).srec
+	avr-size $(@)
+
+clean:
+	-/bin/rm -rf *.elf *.lss *.eep *.hex *.map *.srec $(OBJS)

--- a/VideoGame/main.c
+++ b/VideoGame/main.c
@@ -2,6 +2,8 @@
 #include <avr/io.h>
 #define hSync	5
 
+register uint8_t ZERO asm("r17");
+
 uint8_t lineCounter;
 register uint8_t lineMode asm ("r26");
 uint8_t startingV;
@@ -37,6 +39,23 @@ const uint8_t bugGraphx[] = {
 };
 
 uint8_t bugs[6];
+
+/*
+ * this code completely replaces the interrupt vector table, since it's unused
+ */
+__attribute__((naked,section(".vectors"))) void start(void) {
+	asm volatile("clr __zero_reg__");		// set up r17 (constant 0)
+	SREG = 0;								// ensure status register is clear
+	SP = RAMEND;							// set up stack pointer
+}
+
+/*
+ * instead of an "rcall" to main, use an "rjmp".
+ * the standard exit() function is omitted
+ */
+__attribute__((naked,section(".init9"))) void __init_done(void) {
+	asm volatile("rjmp main");
+}
 
 void heroMissileOff() {
 

--- a/VideoGame/main.c
+++ b/VideoGame/main.c
@@ -52,7 +52,7 @@ void xPos(uint8_t theSpacing) {
 
 }
 
-void gameOver() {
+static void gameOver() {
 
 	gameState = 2;
 	moveSpeed = 10;			//Taunt player
@@ -84,7 +84,7 @@ void drawSprite(uint8_t theData) {
 
 }
 
-void drawPF() {
+static void drawPF() {
 
 	switch(lineMode) {
 		

--- a/VideoGame/main.c
+++ b/VideoGame/main.c
@@ -2,8 +2,6 @@
 #include <avr/io.h>
 #define hSync	5
 
-register uint8_t ZERO asm("r17");
-
 uint8_t lineCounter;
 register uint8_t lineMode asm ("r26");
 uint8_t startingV;


### PR DESCRIPTION
These two changes trim 22 bytes from the binary, and eliminate at least four bytes of stack usage.